### PR TITLE
feat(enable-arm64-compatibility): add a more generic get_platform fun…

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -2,12 +2,27 @@
 set -e
 set -o pipefail
 
+get_arch() {
+  local arch=""
+
+  case "$(uname -m)" in
+    x86_64 | amd64) arch="amd64" ;;
+    i686 | i386) arch="386" ;;
+    aarch64 | arm64) arch="arm64" ;;
+    *)
+      fail "Arch '$(uname -m)' not supported!"
+      ;;
+  esac
+
+  echo -n $arch
+}
+
 install() {
     version=$2
     install_path=$3
     bin_path=${install_path}/bin/kind
     platform=$(uname | tr [:upper:] [:lower:])
-    arch=amd64
+    arch=$(get_arch)
     filename=kind-${platform}-${arch}
     github_base_url=https://github.com/kubernetes-sigs/kind/releases/download
     download_url="${github_base_url}/v${version}/${filename}"


### PR DESCRIPTION
Tested on Macbook pro M1 computer. I didn't tested on an amd computer though.
But this fix is inspired from devspace asdf plugin : https://github.com/NeoHsu/asdf-devspace/blob/1e1cbbd93fe732ef87eb105928f501b6d972c68c/lib/utils.bash#L53
So I'm expecting it to work fine 🤔 But we never know...